### PR TITLE
keep rpmlint happy and return in all cases for Sink::Log::debugOutputFilter

### DIFF
--- a/common/log.cpp
+++ b/common/log.cpp
@@ -200,6 +200,8 @@ QByteArrayList Sink::Log::debugOutputFilter(FilterType type)
             return config()->value("applicationfilter").value<QByteArrayList>();
         case Area:
             return config()->value("areafilter").value<QByteArrayList>();
+        default:
+            return QByteArrayList() << QByteArray("");
     }
 }
 


### PR DESCRIPTION
keep rpmlint happy and return in all cases for Sink::Log::debugOutputFilter
