### PR TITLE
Add an offset support to the query.

### DIFF
--- a/common/query.h
+++ b/common/query.h
@@ -395,13 +395,13 @@ public:
     }
 
 
-    Query(const ApplicationDomain::Entity &value) : mLimit(0)
+    Query(const ApplicationDomain::Entity &value)
     {
         filter(value.identifier());
         resourceFilter(value.resourceInstanceIdentifier());
     }
 
-    Query(Flags flags = Flags()) : mLimit(0), mFlags(flags)
+    Query(Flags flags = Flags()) : mFlags(flags)
     {
     }
 
@@ -436,6 +436,16 @@ public:
     int limit() const
     {
         return mLimit;
+    }
+
+    Query &offset(int o)
+    {
+        return *this;
+    }
+
+    int offset() const
+    {
+        return mOffset;
     }
 
     Filter getResourceFilter() const
@@ -476,7 +486,8 @@ public:
 
 private:
     friend class SyncScope;
-    int mLimit;
+    int mLimit {0};
+    int mOffset {0};
     Flags mFlags;
     Filter mResourceFilter;
     QByteArray mParentProperty;

--- a/common/queryrunner.cpp
+++ b/common/queryrunner.cpp
@@ -267,7 +267,7 @@ ReplayResult QueryWorker<DomainType>::executeInitialQuery(
     auto resultSet = preparedQuery.execute();
 
     SinkTraceCtx(mLogCtx) << "Filtered set retrieved." << Log::TraceTime(time.elapsed());
-    auto replayResult = resultSet.replaySet(0, batchsize, [this, query, &resultProvider](const ResultSet::Result &result) {
+    auto replayResult = resultSet.replaySet(query.offset(), batchsize, [this, query, &resultProvider](const ResultSet::Result &result) {
         resultProviderCallback(query, resultProvider, result);
     });
 


### PR DESCRIPTION
When post processing is necessary, the model driven API can be a bit
cumbersome to use. For those use cases, the lower level object API is
preferred. To make it easier to use, smaller batches are quite useful.

This commit add a way to do small batches.